### PR TITLE
FileName was not used

### DIFF
--- a/src/Microsoft.Extensions.Logging.Log4Net/Log4NetLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net/Log4NetLoggerFactoryExtensions.cs
@@ -29,7 +29,7 @@
       private static ILoggerProvider CreateLog4NetProvider(string configFileName) {
          var fileName = string.IsNullOrEmpty(configFileName) ? "log4net.config" : configFileName;
 
-         return new Log4NetLoggerProvider(configFileName);
+         return new Log4NetLoggerProvider(fileName);
       }
    }
 }


### PR DESCRIPTION
It would cause errors if `CreateLog4NetProvider` is called with `null`